### PR TITLE
feat: add function to store and retrieve general contracts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,11 +60,11 @@ func NewConfig() {
 		fmt.Println("Error getting contracts from json:", err)
 	}
 
-	// // get FPI contracts from tokens.json
-	// fpiCalls := getAllFPI("./config/jsons/tokens.json")
+	// get FPI contracts from tokens.json
+	fpiCalls := getAllFPI("./config/jsons/tokens.json")
 
-	// // append calls to get all contract calls
-	// calls := append(fpiCalls, generalCalls...)
-	ContractCalls = generalCalls
+	// append calls to get all contract calls
+	calls := append(fpiCalls, generalCalls...)
+	ContractCalls = calls
 
 }

--- a/config/config.go
+++ b/config/config.go
@@ -53,11 +53,11 @@ func NewConfig() {
 		fmt.Println("Error getting contracts from json:", err)
 	}
 
-	// get FPI contracts from tokens.json
-	fpiCalls := getAllFPI("./config/jsons/tokens.json")
+	// // get FPI contracts from tokens.json
+	// fpiCalls := getAllFPI("./config/jsons/tokens.json")
 
-	// append calls to get all contract calls
-	calls := append(fpiCalls, generalCalls...)
-	ContractCalls = calls
+	// // append calls to get all contract calls
+	// calls := append(fpiCalls, generalCalls...)
+	ContractCalls = generalCalls
 
 }

--- a/config/jsons/contracts.json
+++ b/config/jsons/contracts.json
@@ -20,7 +20,7 @@
       "Keys": [
         "markets:ccanto",
         "supplyspeeds:ccanto",
-        "borrowcaps"
+        "borrowcaps:ccanto"
       ],
       "Methods": [
         "markets(address)(bool, uint256, bool)",
@@ -37,6 +37,19 @@
         [
           "0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488"
         ]
+      ]
+    },
+    {
+      "Name": "factory",
+      "Address": "0xE387067f12561e579C5f7d4294f51867E0c1cFba",
+      "Keys": [
+        "admin:factory"
+      ],
+      "Methods": [
+        "admin()(address)"
+      ],
+      "Args": [
+        []
       ]
     }
   ]

--- a/config/jsons/contracts.json
+++ b/config/jsons/contracts.json
@@ -1,6 +1,6 @@
 [
     {
-      "Name": "ccanto pricefeed",
+      "Name": "pricefeed",
       "Address": "0xa252eEE9BDe830Ca4793F054B506587027825a8e",
       "Keys": [
         "pricefeed:ccanto"
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "Name":    "ccanto comptroller",
+      "Name":    "comptroller",
       "Address": "0x5E23dC409Fc2F832f83CEc191E245A191a4bCc5C",
       "Keys": [
         "markets:ccanto",
@@ -40,10 +40,10 @@
       ]
     },
     {
-      "Name": "factory",
+      "Name": "factoryafsd",
       "Address": "0xE387067f12561e579C5f7d4294f51867E0c1cFba",
       "Keys": [
-        "admin:factory"
+        "key"
       ],
       "Methods": [
         "admin()(address)"

--- a/config/jsons/contracts.json
+++ b/config/jsons/contracts.json
@@ -53,7 +53,7 @@
       ]
     },
     {
-      "Name": "factoryafsd",
+      "Name": "factory again",
       "Address": "0xE387067f12561e579C5f7d4294f51867E0c1cFba",
       "Keys": [
         "key"

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func routerLiquidityPool(app *fiber.App) {
 }
 
 func routerLending(app *fiber.App) {
-	lending := app.Group("/lending")
+	lending := app.Group("/ctokens")
 	lending.Get("/", re.QueryLending)
 	lending.Get("/:address", re.QueryLendingByAddress)
 }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,18 @@ func main() {
 		AppName:      "Canto API",
 		ServerHeader: "Fiber",
 	})
-	app.Get("/", re.GetSmartContractDataFiber)
+	app.Get("/", re.GetGeneralContractDataFiber)
+
+	routes := []string{
+		"/pricefeed/ccanto/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
+		"/borrowcaps/ccanto/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
+		"/supplyspeeds/ccanto/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
+		"/admin/factory",
+	}
+
+	for _, route := range routes {
+		app.Get(route, re.GetGeneralContractDataFiber)
+	}
 
 	routerValidator(app)
 	routerCSR(app)

--- a/main.go
+++ b/main.go
@@ -25,10 +25,10 @@ func main() {
 	app.Get("/", re.GetGeneralContractDataFiber)
 
 	routes := []string{
-		"/pricefeed/ccanto/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
-		"/borrowcaps/ccanto/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
-		"/supplyspeeds/ccanto/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
-		"/admin/factory",
+		"/pricefeed/getUnderlyingPrice/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
+		"/comptroller/borrowCaps/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
+		"/comptroller/compSupplySpeeds/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
+		"/factory/admin",
 	}
 
 	for _, route := range routes {

--- a/multicall/viewcall.go
+++ b/multicall/viewcall.go
@@ -235,7 +235,12 @@ func (calls ViewCalls) Decode(raw struct {
 			callResult = returnValues
 
 		}
-		result.Calls[call.key] = callResult
+		if len(call.arguments) == 0 {
+			result.Calls[call.key] = callResult
+		} else {
+			argumentString := call.arguments[0].(string)
+			result.Calls[call.key+":"+argumentString] = callResult
+		}
 	}
 	return result, nil
 }

--- a/multicall/viewcall.go
+++ b/multicall/viewcall.go
@@ -237,6 +237,14 @@ func (calls ViewCalls) Decode(raw struct {
 			callResult = returnValues
 
 		}
+
+		// store ctokens and lppairs in separate maps
+		if strings.Split(call.key, ":")[0] == "cTokens" {
+			result.Calls[call.key] = callResult
+		} else if strings.Split(call.key, ":")[0] == "lpPairs" {
+			result.Calls[call.key] = callResult
+		}
+
 		if len(call.arguments) == 0 {
 			result.Calls[call.contract+":"+strings.Split(call.method, "(")[0]] = callResult
 		} else {

--- a/multicall/viewcall.go
+++ b/multicall/viewcall.go
@@ -14,6 +14,7 @@ import (
 )
 
 type ViewCall struct {
+	contract  string
 	key       string
 	target    string
 	method    string
@@ -30,8 +31,9 @@ type Result struct {
 var insideParens = regexp.MustCompile("\\(.*?\\)")
 var numericArg = regexp.MustCompile("u?int(256)|(8)")
 
-func NewViewCall(key string, target string, method string, arguments []interface{}) ViewCall {
+func NewViewCall(contract string, key string, target string, method string, arguments []interface{}) ViewCall {
 	return ViewCall{
+		contract:  contract,
 		key:       key,
 		target:    target,
 		method:    method,
@@ -236,10 +238,13 @@ func (calls ViewCalls) Decode(raw struct {
 
 		}
 		if len(call.arguments) == 0 {
-			result.Calls[call.key] = callResult
+			result.Calls[call.contract+":"+strings.Split(call.method, "(")[0]] = callResult
 		} else {
+			// create key string
 			argumentString := call.arguments[0].(string)
-			result.Calls[call.key+":"+argumentString] = callResult
+			contractString := call.contract
+			methodString := strings.Split(call.method, "(")[0]
+			result.Calls[contractString+":"+methodString+":"+argumentString] = callResult
 		}
 	}
 	return result, nil

--- a/query/contracts/query_contracts.go
+++ b/query/contracts/query_contracts.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -79,7 +80,7 @@ func (qe *QueryEngine) ProcessMulticallResults(ctx context.Context, results *mul
 	pairs := make(PairsMap)
 	others := make(map[string]interface{})
 
-	// Iterate the results to segregate them into ctokens, pairs and other according to their keys
+	// Iterate the results to separate them into ctokens, pairs and other according to their keys
 	for key, value := range results.Calls {
 		// split the keys at ':'
 		keys := strings.Split(key, ":")
@@ -105,6 +106,7 @@ func (qe *QueryEngine) ProcessMulticallResults(ctx context.Context, results *mul
 			pairs[keys[1]][keys[2]] = value
 
 		} else {
+			fmt.Println(key)
 			others[key] = value
 		}
 
@@ -180,13 +182,15 @@ func (qe *QueryEngine) StartQueryEngine(ctx context.Context) {
 		}
 
 		// get ctokens, pairs and others from multicall results
-		ctokens, pairs, others := qe.ProcessMulticallResults(ctx, ret)
+		_, _, others := qe.ProcessMulticallResults(ctx, ret)
 
 		// set ctokens, pairs to redis cache with fpi
-		err = qe.SetCacheWithFpi(ctx, qe.redisclient, ctokens, pairs)
-		if err != nil {
-			log.Fatal(err)
-		}
+		// err = qe.SetCacheWithFpi(ctx, qe.redisclient, ctokens, pairs)
+		// if err != nil {
+		// 	log.Fatal(err)
+		// }
+
+		// fmt.Println(others)
 
 		// set results to redis cache
 		err = qe.SetCacheWithResult(ctx, qe.redisclient, others)

--- a/query/contracts/query_contracts.go
+++ b/query/contracts/query_contracts.go
@@ -37,6 +37,7 @@ func NewQueryEngine() *QueryEngine {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	return &QueryEngine{
 		redisclient: config.RDB,
 		interval:    time.Duration(config.QueryInterval),
@@ -180,13 +181,13 @@ func (qe *QueryEngine) StartQueryEngine(ctx context.Context) {
 		}
 
 		// get ctokens, pairs and others from multicall results
-		_, _, others := qe.ProcessMulticallResults(ctx, ret)
+		ctokens, pairs, others := qe.ProcessMulticallResults(ctx, ret)
 
 		// set ctokens, pairs to redis cache with fpi
-		// err = qe.SetCacheWithFpi(ctx, qe.redisclient, ctokens, pairs)
-		// if err != nil {
-		// 	log.Fatal(err)
-		// }
+		err = qe.SetCacheWithFpi(ctx, qe.redisclient, ctokens, pairs)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		// set results to redis cache
 		err = qe.SetCacheWithResult(ctx, qe.redisclient, others)

--- a/query/contracts/query_contracts.go
+++ b/query/contracts/query_contracts.go
@@ -3,7 +3,6 @@ package query
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -57,6 +56,7 @@ func ProcessContractCalls(contracts []config.Contract) (multicall.ViewCalls, err
 				return nil, err
 			}
 			vc := multicall.NewViewCall(
+				contract.Name,
 				contract.Keys[index],
 				contract.Address,
 				method,
@@ -84,7 +84,6 @@ func (qe *QueryEngine) ProcessMulticallResults(ctx context.Context, results *mul
 	for key, value := range results.Calls {
 		// split the keys at ':'
 		keys := strings.Split(key, ":")
-
 		if keys[0] == "cTokens" {
 			// Check if the keys[1] map(ex: cCanto) is already initialized
 			if ctokens[keys[1]] == nil {
@@ -106,7 +105,6 @@ func (qe *QueryEngine) ProcessMulticallResults(ctx context.Context, results *mul
 			pairs[keys[1]][keys[2]] = value
 
 		} else {
-			fmt.Println(key)
 			others[key] = value
 		}
 
@@ -189,8 +187,6 @@ func (qe *QueryEngine) StartQueryEngine(ctx context.Context) {
 		// if err != nil {
 		// 	log.Fatal(err)
 		// }
-
-		// fmt.Println(others)
 
 		// set results to redis cache
 		err = qe.SetCacheWithResult(ctx, qe.redisclient, others)

--- a/query/contracts/query_contracts_test.go
+++ b/query/contracts/query_contracts_test.go
@@ -38,6 +38,7 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
+				"name",
 				"decimals:0x00",
 				"0x00",
 				"decimals()",
@@ -65,6 +66,7 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
+				"name",
 				"decimals:0x0000000000000000000000000000000000000000",
 				"0x0000000000000000000000000000000000000000",
 				"decimals()",
@@ -94,6 +96,7 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
+				"name",
 				"balanceof:0x0000000000000000000000000000000000000000",
 				"0x0000000000000000000000000000000000000000",
 				"balanceOf(address)(uint256)",
@@ -130,12 +133,14 @@ func TestProcessContractCalls(t *testing.T) {
 			},
 			want: multicall.ViewCalls{
 				multicall.NewViewCall(
+					"name",
 					"balanceof:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"balanceOf(address)(uint256)",
 					[]interface{}{"0x71C7656EC7ab88b098defB751B7401B5f6d8976F"},
 				),
 				multicall.NewViewCall(
+					"name",
 					"allowance:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"allowance(address,address)(uint256)",
@@ -191,12 +196,14 @@ func TestProcessContractCalls(t *testing.T) {
 			},
 			want: multicall.ViewCalls{
 				multicall.NewViewCall(
+					"name",
 					"balanceof:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"balanceOf(address)(uint256)",
 					[]interface{}{"0x71C7656EC7ab88b098defB751B7401B5f6d8976F"},
 				),
 				multicall.NewViewCall(
+					"name",
 					"allowance:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"allowance(address,address)(uint256)",
@@ -206,6 +213,7 @@ func TestProcessContractCalls(t *testing.T) {
 					},
 				),
 				multicall.NewViewCall(
+					"name",
 					"balanceof:0x0000000000000000000000000000000000000001",
 					"0x0000000000000000000000000000000000000001",
 					"balanceOf(address)(uint256)",

--- a/query/contracts/query_contracts_test.go
+++ b/query/contracts/query_contracts_test.go
@@ -38,7 +38,7 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
-				"name",
+				"base contract",
 				"decimals:0x00",
 				"0x00",
 				"decimals()",
@@ -66,7 +66,7 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
-				"name",
+				"base contract",
 				"decimals:0x0000000000000000000000000000000000000000",
 				"0x0000000000000000000000000000000000000000",
 				"decimals()",
@@ -96,7 +96,7 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
-				"name",
+				"sample erc20",
 				"balanceof:0x0000000000000000000000000000000000000000",
 				"0x0000000000000000000000000000000000000000",
 				"balanceOf(address)(uint256)",
@@ -133,14 +133,14 @@ func TestProcessContractCalls(t *testing.T) {
 			},
 			want: multicall.ViewCalls{
 				multicall.NewViewCall(
-					"name",
+					"sample erc20",
 					"balanceof:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"balanceOf(address)(uint256)",
 					[]interface{}{"0x71C7656EC7ab88b098defB751B7401B5f6d8976F"},
 				),
 				multicall.NewViewCall(
-					"name",
+					"sample erc20",
 					"allowance:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"allowance(address,address)(uint256)",
@@ -196,14 +196,14 @@ func TestProcessContractCalls(t *testing.T) {
 			},
 			want: multicall.ViewCalls{
 				multicall.NewViewCall(
-					"name",
+					"sample erc20",
 					"balanceof:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"balanceOf(address)(uint256)",
 					[]interface{}{"0x71C7656EC7ab88b098defB751B7401B5f6d8976F"},
 				),
 				multicall.NewViewCall(
-					"name",
+					"sample erc20",
 					"allowance:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"allowance(address,address)(uint256)",
@@ -213,7 +213,7 @@ func TestProcessContractCalls(t *testing.T) {
 					},
 				),
 				multicall.NewViewCall(
-					"name",
+					"sample pair",
 					"balanceof:0x0000000000000000000000000000000000000001",
 					"0x0000000000000000000000000000000000000001",
 					"balanceOf(address)(uint256)",

--- a/query/contracts/utils_test.go
+++ b/query/contracts/utils_test.go
@@ -24,6 +24,7 @@ func TestGetCallData(t *testing.T) {
 			name: "function with no argument",
 			args: args{
 				vcs: multicall.ViewCalls{multicall.NewViewCall(
+					"name",
 					"decimals:0x0000",
 					"0x0000",
 					"decimals()",
@@ -42,6 +43,7 @@ func TestGetCallData(t *testing.T) {
 			name: "function with one argument",
 			args: args{
 				vcs: multicall.ViewCalls{multicall.NewViewCall(
+					"name",
 					"balanceof:0x0000",
 					"0x0000",
 					"balanceOf(address)(uint256)",
@@ -62,6 +64,7 @@ func TestGetCallData(t *testing.T) {
 			name: "function with multiple arguments",
 			args: args{
 				vcs: multicall.ViewCalls{multicall.NewViewCall(
+					"name",
 					"dosomething:0x0000",
 					"0x0000",
 					"doSomething(address,address,uint256)(uint256)",

--- a/requests/serve.go
+++ b/requests/serve.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -12,10 +13,33 @@ import (
 	"canto-api/rediskeys"
 )
 
+func GetGeneralContractDataFiber(ctx *fiber.Ctx) error {
+
+	// assemble key from route
+	var key string
+	route := strings.Split(ctx.Route().Path, `/`)
+
+	for index, part := range route {
+		if index > 1 {
+			key += ":" + part
+		} else if index == 1 {
+			key += part
+		}
+	}
+
+	rdb := config.RDB
+	val, err := rdb.Get(context.Background(), key).Result()
+	if err != nil {
+		panic(err)
+	}
+	return ctx.SendString(val)
+}
+
 func GetSmartContractDataFiber(ctx *fiber.Ctx) error {
+
 	rdb := config.RDB
 
-	val, err := rdb.Get(context.Background(), "ctokens").Result()
+	val, err := rdb.Get(context.Background(), "supplyspeeds:ccanto:0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488").Result()
 	if err != nil {
 		panic(err)
 	}

--- a/requests/serve.go
+++ b/requests/serve.go
@@ -76,12 +76,12 @@ func QueryLpByAddress(ctx *fiber.Ctx) error {
 }
 
 func QueryLending(ctx *fiber.Ctx) error {
-	return ctx.SendString(getStoreValueFromKey("lending"))
+	return ctx.SendString(getStoreValueFromKey("ctokens"))
 }
 
 func QueryLendingByAddress(ctx *fiber.Ctx) error {
 	allCTokens := new([]config.Token)
-	cTokensJson := getStoreValueFromKey("lending")
+	cTokensJson := getStoreValueFromKey("ctokens")
 	err := json.Unmarshal([]byte(cTokensJson), &allCTokens)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Describe your changes
This feature adds functionality for users to add any contract to contract.json. The backend will then parse the key to automatically create routes for the contract. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added a good description to this PR
- [x] I have linked the ticket to this PR
