### PR TITLE
feat:add support for router, comptroller and factory contracts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	RDB              *redis.Client
-	EthClient        *ethclient.Client
-	GrpcClient       *grpc.ClientConn
-	ContractCalls    []Contract // list of calls to make
-	MulticallAddress common.Address
-	QueryInterval    uint
-	TokensConfig     TokensInfo
+	RDB                     *redis.Client
+	EthClient               *ethclient.Client
+	GrpcClient              *grpc.ClientConn
+	ContractCalls           []Contract // list of calls to make
+	MulticallAddress        common.Address
+	QueryInterval           uint
+	TokensConfig            TokensInfo
+	ContractAddressesConfig ContractAddresses
 )
 
 /*
@@ -47,6 +48,12 @@ func NewConfig() {
 	// set query interval per block (5 seconds)
 	QueryInterval = 5
 
+	// get tokens data from tokens.json
+	TokensConfig = getAllTokensFromJson("./config/jsons/tokens.json")
+
+	// get contract addresses data from contract_addresses.json
+	ContractAddressesConfig = getContractAddressesFromJson("./config/jsons/contract_addresses.json")
+
 	// get general contracts from contracts.json
 	generalCalls, err := getContractsFromJson("./config/jsons/contracts.json")
 	if err != nil {
@@ -59,6 +66,4 @@ func NewConfig() {
 	// append calls to get all contract calls
 	calls := append(fpiCalls, generalCalls...)
 	ContractCalls = calls
-
-	fmt.Println("contract calls: ", ContractCalls)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -66,4 +66,5 @@ func NewConfig() {
 	// append calls to get all contract calls
 	calls := append(fpiCalls, generalCalls...)
 	ContractCalls = calls
+
 }

--- a/config/fpi.go
+++ b/config/fpi.go
@@ -19,7 +19,7 @@ func getCTokenContractCalls() []Contract {
 			Name:    token.Symbol,
 			Address: token.Address,
 			Keys: []string{
-				"cTokens:" + token.Symbol + ":getCash",
+				"cTokens:" + token.Symbol + ":cash",
 				"cTokens:" + token.Symbol + ":exchangeRateStored",
 				"cTokens:" + token.Symbol + ":supplyRatePerBlock",
 				"cTokens:" + token.Symbol + ":borrowRatePerBlock",
@@ -43,7 +43,7 @@ func getCTokenContractCalls() []Contract {
 			Name:    token.Symbol + "pricefeed",
 			Address: ContractAddressesConfig.Mainnet.Router,
 			Keys: []string{
-				"cTokens:" + token.Symbol + ":getUnderlyingPrice",
+				"cTokens:" + token.Symbol + ":underlyingPrice",
 			},
 			Methods: []string{
 				"getUnderlyingPrice(address)(uint256)",
@@ -127,10 +127,10 @@ func getPairsContractsCalls() []Contract {
 			Name:    pair.Symbol + "pricefeed",
 			Address: ContractAddressesConfig.Mainnet.Router,
 			Keys: []string{
-				"lpPairs:" + pair.Symbol + ":getReserves",
-				"lpPairs:" + pair.Symbol + ":getUnderlyingPriceTokenA",
-				"lpPairs:" + pair.Symbol + ":getUnderlyingPriceTokenB",
-				"lpPairs:" + pair.Symbol + ":getUnderlyingPriceLp",
+				"lpPairs:" + pair.Symbol + ":reserves",
+				"lpPairs:" + pair.Symbol + ":underlyingPriceTokenA",
+				"lpPairs:" + pair.Symbol + ":underlyingPriceTokenB",
+				"lpPairs:" + pair.Symbol + ":underlyingPriceLp",
 			},
 			Methods: []string{
 				"getReserves(address,address,bool)(uint256, uint256)",

--- a/config/fpi.go
+++ b/config/fpi.go
@@ -1,26 +1,28 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 )
 
+// this function generates and returns required contract calls for all ctokens in TokensConfig
 func getCTokenContractCalls() []Contract {
-
+	// Declare and initialize a list of Contracts
 	calls := []Contract{}
 
-	//get cTokens
+	// iterate over all ctokens in config and generate contract calls to query required ctoken data
 	for _, token := range TokensConfig.CTokens {
-		tokenKey := token.Symbol
+		// get required ctoken data from its contract
 		calls = append(calls, Contract{
-			Name:    token.Name,
+			Name:    token.Symbol,
 			Address: token.Address,
 			Keys: []string{
-				"cTokens:" + tokenKey + ":getCash",
-				"cTokens:" + tokenKey + ":exchangeRateStored",
-				"cTokens:" + tokenKey + ":supplyRatePerBlock",
-				"cTokens:" + tokenKey + ":borrowRatePerBlock",
+				"cTokens:" + token.Symbol + ":getCash",
+				"cTokens:" + token.Symbol + ":exchangeRateStored",
+				"cTokens:" + token.Symbol + ":supplyRatePerBlock",
+				"cTokens:" + token.Symbol + ":borrowRatePerBlock",
 			},
 			Methods: []string{
 				"getCash()(uint256)",
@@ -35,32 +37,112 @@ func getCTokenContractCalls() []Contract {
 				{},
 			},
 		})
+
+		// getUnderlyingPrice data of ctoken from router contract
+		calls = append(calls, Contract{
+			Name:    token.Symbol + "pricefeed",
+			Address: ContractAddressesConfig.Mainnet.Router,
+			Keys: []string{
+				"cTokens:" + token.Symbol + ":getUnderlyingPrice",
+			},
+			Methods: []string{
+				"getUnderlyingPrice(address)(uint256)",
+			},
+			Args: [][]interface{}{
+				{token.Address},
+			},
+		})
+
+		// get markets, compSupplySpeeds and borrowCaps data of ctoken from comptroller contract
+		calls = append(calls, Contract{
+			Name:    token.Symbol + "comptroller",
+			Address: ContractAddressesConfig.Mainnet.Comptroller,
+			Keys: []string{
+				"cTokens:" + token.Symbol + ":markets",
+				"cTokens:" + token.Symbol + ":compSupplySpeeds",
+				"cTokens:" + token.Symbol + ":borrowCaps",
+			},
+			Methods: []string{
+				"markets(address)(bool, uint256, bool)",
+				"compSupplySpeeds(address)(uint256)",
+				"borrowCaps(address)(uint256)",
+			},
+			Args: [][]interface{}{
+				{token.Address},
+				{token.Address},
+				{token.Address},
+			},
+		})
 	}
+
 	return calls
 }
 
+// this function returns the ctoken address of the token having address equal to underlyingAddress
+func getCTokenAddress(underlyingAddress string) string {
+	// Declare cNoteAddress which wll be returned when ctoken is not found for underlyingAddress
+	var cNoteAddress string
+
+	// iterate through ctokens config to get the ctoken address of the token with underlyingAddress
+	for _, token := range TokensConfig.CTokens {
+		//check if the current ctoken is cnote and store its address
+		if token.Symbol == "cNOTE" {
+			cNoteAddress = token.Address
+		}
+
+		// check if the current ctoken has given underlying address and return ctoken address if true
+		if token.Underlying == underlyingAddress {
+			return token.Address
+		}
+	}
+
+	// return cnote address when token with underlyingAddress is not found in ctokens list
+	return cNoteAddress
+}
+
+// this function generates and returns required contract calls for all pairs in TokensConfig
 func getPairsContractsCalls() []Contract {
+	// Declare and initialize a list of Contracts
 	calls := []Contract{}
 
+	// iterare over all the pairs in config and generate contract calls to query required pair data
 	for _, pair := range TokensConfig.Pairs {
-		pairKey := pair.Symbol
+		// get required pair data from its contract
 		calls = append(calls, Contract{
-			Name:    pair.Name,
+			Name:    pair.Symbol,
 			Address: pair.Address,
 			Keys: []string{
-				"lpPairs:" + pairKey + ":reserves",
-				"lpPairs:" + pairKey + ":tokens",
-				"lpPairs:" + pairKey + ":stable",
+				"lpPairs:" + pair.Symbol + ":totalSupply",
 			},
 			Methods: []string{
-				"getReserves()(uint256,uint256,uint256)",
-				"tokens()(address,address)",
-				"stable()(bool)",
+				"totalSupply()(uint256)",
 			},
 			Args: [][]interface{}{
 				{},
-				{},
-				{},
+			},
+		})
+
+		// get reserves, underlying prices of tokenA, tokenB and Lp from router contract
+		calls = append(calls, Contract{
+			Name:    pair.Symbol + "pricefeed",
+			Address: ContractAddressesConfig.Mainnet.Router,
+			Keys: []string{
+				"lpPairs:" + pair.Symbol + ":getReserves",
+				"lpPairs:" + pair.Symbol + ":getUnderlyingPriceTokenA",
+				"lpPairs:" + pair.Symbol + ":getUnderlyingPriceTokenB",
+				"lpPairs:" + pair.Symbol + ":getUnderlyingPriceLp",
+			},
+			Methods: []string{
+				"getReserves(address,address,bool)(uint256, uint256)",
+				"getUnderlyingPrice(address)(uint256)",
+				"getUnderlyingPrice(address)(uint256)",
+				"getUnderlyingPrice(address)(uint256)",
+			},
+			Args: [][]interface{}{
+				{pair.TokenA, pair.TokenB, pair.Stable},
+				{getCTokenAddress(pair.TokenA)},
+				{getCTokenAddress(pair.TokenB)},
+				{getCTokenAddress(pair.Address)},
 			},
 		})
 	}
@@ -68,7 +150,7 @@ func getPairsContractsCalls() []Contract {
 
 }
 
-// read jsoon to get all tokens and set them to TokensConfig
+// parses tokens.json and returns tokens data
 func getAllTokensFromJson(path string) TokensInfo {
 	var TokensInfo TokensInfo
 
@@ -92,11 +174,40 @@ func getAllTokensFromJson(path string) TokensInfo {
 	return TokensInfo
 }
 
-func getAllFPI(path string) []Contract {
-	calls := []Contract{}
-	TokensConfig = getAllTokensFromJson(path)
+// parses contract_addresses.json and returns contract addresses for all chains
+func getContractAddressesFromJson(path string) ContractAddresses {
+	var contractAddresses ContractAddresses
 
+	// Open the JSON file
+	file, err := os.Open(path)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	defer file.Close()
+
+	// Read the file content
+	fileContent, _ := io.ReadAll(file)
+
+	//Umarshall the data and store in contractAddresses
+	err = json.Unmarshal(fileContent, &contractAddresses)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return contractAddresses
+}
+
+func getAllFPI(path string) []Contract {
+	// Declare and initialize a list of Contracts
+	calls := []Contract{}
+
+	// add required contract calls for all cTokens
 	calls = append(calls, getCTokenContractCalls()...)
+
+	// add required contract calls for all pairs
 	calls = append(calls, getPairsContractsCalls()...)
 
 	return calls

--- a/config/fpi.go
+++ b/config/fpi.go
@@ -108,12 +108,21 @@ func getPairsContractsCalls() []Contract {
 			Name:    pair.Symbol,
 			Address: pair.Address,
 			Keys: []string{
+				"lpPairs:" + pair.Symbol + ":reserves",
+				"lpPairs:" + pair.Symbol + ":tokens",
+				"lpPairs:" + pair.Symbol + ":stable",
 				"lpPairs:" + pair.Symbol + ":totalSupply",
 			},
 			Methods: []string{
+				"getReserves()(uint256,uint256,uint256)",
+				"tokens()(address,address)",
+				"stable()(bool)",
 				"totalSupply()(uint256)",
 			},
 			Args: [][]interface{}{
+				{},
+				{},
+				{},
 				{},
 			},
 		})

--- a/config/fpi.go
+++ b/config/fpi.go
@@ -80,24 +80,20 @@ func getCTokenContractCalls() []Contract {
 
 // this function returns the ctoken address of the token having address equal to underlyingAddress
 func getCTokenAddress(underlyingAddress string) string {
-	// Declare cNoteAddress which wll be returned when ctoken is not found for underlyingAddress
-	var cNoteAddress string
+	// Declare cTokenAddress
+	var cTokenAddress string
 
 	// iterate through ctokens config to get the ctoken address of the token with underlyingAddress
 	for _, token := range TokensConfig.CTokens {
-		//check if the current ctoken is cnote and store its address
-		if token.Symbol == "cNOTE" {
-			cNoteAddress = token.Address
-		}
-
 		// check if the current ctoken has given underlying address and return ctoken address if true
 		if token.Underlying == underlyingAddress {
-			return token.Address
+			cTokenAddress = token.Address
+			break
 		}
 	}
 
-	// return cnote address when token with underlyingAddress is not found in ctokens list
-	return cNoteAddress
+	// return cTokenAddress
+	return cTokenAddress
 }
 
 // this function generates and returns required contract calls for all pairs in TokensConfig

--- a/config/jsons/contract_addresses.json
+++ b/config/jsons/contract_addresses.json
@@ -1,0 +1,19 @@
+{
+    "mainnet": {
+      "comptroller": "0x5E23dC409Fc2F832f83CEc191E245A191a4bCc5C",
+      "router": "0xa252eEE9BDe830Ca4793F054B506587027825a8e",
+      "reservoir": "0x07C50Bf0804A06860AeACAcFaf029F9a1c014F91",
+      "multicallV1": "0x210b88d5Ad4BEbc8FAC4383cC7F84Cd4F03d18c6",
+      "multicallV2": "0x637490E68AA50Ea810688a52D7464E10c25A77c1",
+      "multicallV3": "0xcA11bde05977b3631167028862bE2a173976CA11"
+     
+    },
+    "testnet": {
+      "comptroller": "0x9514c07bC6e80B652e4264E64f589C59065C231f",
+      "router": "0x463e7d4DF8fE5fb42D024cb57c77b76e6e74417a",
+      "reservoir": "0x07C50Bf0804A06860AeACAcFaf029F9a1c014F91",
+      "multicallV1": "0xe536cF7B00069894da25faC787d7aD9D211a2C1A",
+      "multicallV2": "0x0e356B86FA2aE1bEB93174C18AD373207a40F2A3",
+      "multicallV3": "0x0e356B86FA2aE1bEB93174C18AD373207a40F2A3"
+    }
+  }

--- a/config/jsons/contracts.json
+++ b/config/jsons/contracts.json
@@ -1,5 +1,18 @@
 [
     {
+      "Name": "factory contract",
+      "Address": "0xE387067f12561e579C5f7d4294f51867E0c1cFba",
+      "Keys": [
+        "factory:allPairsLength"
+      ],
+      "Methods": [
+        "allPairsLength()(uint256)"
+      ],
+      "Args": [
+        []
+      ]
+    },
+    {
       "Name": "ccanto pricefeed",
       "Address": "0xa252eEE9BDe830Ca4793F054B506587027825a8e",
       "Keys": [
@@ -20,7 +33,7 @@
       "Keys": [
         "markets:ccanto",
         "supplyspeeds:ccanto",
-        "borrowcaps"
+        "borrowcaps:ccanto"
       ],
       "Methods": [
         "markets(address)(bool, uint256, bool)",

--- a/config/token_parser.go
+++ b/config/token_parser.go
@@ -29,13 +29,13 @@ type TokensInfo struct {
 }
 
 type Token struct {
-	Name       string  `json:"name"`
-	Address    string  `json:"address"`
-	Symbol     string  `json:"symbol"`
-	Decimals   int64   `json:"decimals"`
-	Underlying *string `json:"underlying,omitempty"`
-	ChainID    string  `json:"chainId"`
-	LogoURI    *string `json:"logoURI,omitempty"`
+	Name       string `json:"name"`
+	Address    string `json:"address"`
+	Symbol     string `json:"symbol"`
+	Decimals   int64  `json:"decimals"`
+	Underlying string `json:"underlying,omitempty"`
+	ChainID    string `json:"chainId"`
+	LogoURI    string `json:"logoURI,omitempty"`
 }
 
 type Pair struct {
@@ -47,4 +47,17 @@ type Pair struct {
 	TokenA   string `json:"tokenA"`
 	TokenB   string `json:"tokenB"`
 	ChainID  string `json:"chainId"`
+}
+
+type ContractAddresses struct {
+	Mainnet ContractList `json:"mainnet"`
+	Testnet ContractList `json:"testnet"`
+}
+type ContractList struct {
+	Comptroller string `json:"comptroller"`
+	Router      string `json:"router"`
+	Reservoir   string `json:"reservoir"`
+	MulticallV1 string `json:"multicallV1"`
+	MulticallV2 string `json:"multicallV2"`
+	MulticallV3 string `json:"multicallV3"`
 }


### PR DESCRIPTION
## Describe your changes
Added config for router and comptroller  contracts. Added contract calls to query router, comptroller and factory data for pairs and ctokens 

## Tasks
- [x] added contract_addresses.json config to store the router, comptroller etc contract addresses
- [x] updated config.go to fetch and store tokens and contract addresses to global config variables
- [x] added router and comptroller contract calls to pairs and ctokens in fpi.go
- [x] added factory contracts calls to contracts.json

## Issue ticket number and link
[Ticket [ENG-760](https://linear.app/plexengineer/issue/ENG-760/feat-add-support-for-dex-router-and-factory-contracts-in-contractsjson)]
[Ticket [ENG-763](https://linear.app/plexengineer/issue/ENG-763/featadd-all-the-required-contract-calls-for-lending-market-and)]


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added a good description to this PR
- [x] I have linked the ticket to this PR
