### PR TITLE
add routes for general contracts

### DIFF
--- a/config/jsons/contracts.json
+++ b/config/jsons/contracts.json
@@ -1,10 +1,7 @@
 [
     {
-      "Name": "factory contract",
+      "Name": "factory",
       "Address": "0xE387067f12561e579C5f7d4294f51867E0c1cFba",
-      "Keys": [
-        "factory:allPairsLength"
-      ],
       "Methods": [
         "allPairsLength()(uint256)"
       ],
@@ -13,11 +10,8 @@
       ]
     },
     {
-      "Name": "ccanto pricefeed",
+      "Name": "pricefeed",
       "Address": "0xa252eEE9BDe830Ca4793F054B506587027825a8e",
-      "Keys": [
-        "pricefeed:ccanto"
-      ],
       "Methods": [
         "getUnderlyingPrice(address)(uint256)"
       ],
@@ -30,11 +24,6 @@
     {
       "Name":    "comptroller",
       "Address": "0x5E23dC409Fc2F832f83CEc191E245A191a4bCc5C",
-      "Keys": [
-        "markets:ccanto",
-        "supplyspeeds:ccanto",
-        "borrowcaps:ccanto"
-      ],
       "Methods": [
         "markets(address)(bool, uint256, bool)",
         "compSupplySpeeds(address)(uint256)",
@@ -53,11 +42,8 @@
       ]
     },
     {
-      "Name": "factory again",
+      "Name": "factoryagain",
       "Address": "0xE387067f12561e579C5f7d4294f51867E0c1cFba",
-      "Keys": [
-        "key"
-      ],
       "Methods": [
         "admin()(address)"
       ],

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"canto-api/config"
 	cqe "canto-api/query/contracts"
@@ -10,6 +12,28 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 )
+
+// getGeneralContractRoutes returns a slice of routes for general contracts
+func getGeneralContractRoutes() []string {
+	routes := []string{}
+	for _, contract := range config.ContractCalls {
+		for index, method := range contract.Methods {
+			// check if the contract has keys
+			if len(contract.Keys) == 0 {
+				// generate route from name, method and argument of contracts
+				route := contract.Name + "/" + strings.Split(method, "(")[0]
+
+				if len(contract.Args[index]) != 0 {
+					route += "/" + fmt.Sprintf("%v", contract.Args[index][0])
+				}
+
+				routes = append(routes, route)
+			}
+		}
+	}
+
+	return routes
+}
 
 func main() {
 
@@ -24,12 +48,8 @@ func main() {
 	})
 	app.Get("/", re.GetGeneralContractDataFiber)
 
-	routes := []string{
-		"/pricefeed/getUnderlyingPrice/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
-		"/comptroller/borrowCaps/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
-		"/comptroller/compSupplySpeeds/0xB65Ec550ff356EcA6150F733bA9B954b2e0Ca488",
-		"/factory/admin",
-	}
+	// get all general contract routes
+	routes := getGeneralContractRoutes()
 
 	for _, route := range routes {
 		app.Get(route, re.GetGeneralContractDataFiber)

--- a/multicall/viewcall.go
+++ b/multicall/viewcall.go
@@ -14,7 +14,6 @@ import (
 )
 
 type ViewCall struct {
-	contract  string
 	key       string
 	target    string
 	method    string
@@ -31,9 +30,8 @@ type Result struct {
 var insideParens = regexp.MustCompile("\\(.*?\\)")
 var numericArg = regexp.MustCompile("u?int(256)|(8)")
 
-func NewViewCall(contract string, key string, target string, method string, arguments []interface{}) ViewCall {
+func NewViewCall(key string, target string, method string, arguments []interface{}) ViewCall {
 	return ViewCall{
-		contract:  contract,
 		key:       key,
 		target:    target,
 		method:    method,
@@ -237,23 +235,7 @@ func (calls ViewCalls) Decode(raw struct {
 			callResult = returnValues
 
 		}
-
-		// store ctokens and lppairs in separate maps
-		if strings.Split(call.key, ":")[0] == "cTokens" {
-			result.Calls[call.key] = callResult
-		} else if strings.Split(call.key, ":")[0] == "lpPairs" {
-			result.Calls[call.key] = callResult
-		}
-
-		if len(call.arguments) == 0 {
-			result.Calls[call.contract+":"+strings.Split(call.method, "(")[0]] = callResult
-		} else {
-			// create key string
-			argumentString := call.arguments[0].(string)
-			contractString := call.contract
-			methodString := strings.Split(call.method, "(")[0]
-			result.Calls[contractString+":"+methodString+":"+argumentString] = callResult
-		}
+		result.Calls[call.key] = callResult
 	}
 	return result, nil
 }

--- a/query/contracts/query_contracts.go
+++ b/query/contracts/query_contracts.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -56,9 +57,19 @@ func ProcessContractCalls(contracts []config.Contract) (multicall.ViewCalls, err
 			if err := validateAddress(contract.Address); err != nil {
 				return nil, err
 			}
+			var key string
+			// check if the contract has keys
+			if len(contract.Keys) == 0 {
+				// generate key from name, method and argument of contracts
+				key = contract.Name + ":" + strings.Split(method, "(")[0]
+				if len(contract.Args[index]) != 0 {
+					key += ":" + fmt.Sprintf("%v", contract.Args[index][0])
+				}
+			} else {
+				key = contract.Keys[index]
+			}
 			vc := multicall.NewViewCall(
-				contract.Name,
-				contract.Keys[index],
+				key,
 				contract.Address,
 				method,
 				contract.Args[index],

--- a/query/contracts/query_contracts_test.go
+++ b/query/contracts/query_contracts_test.go
@@ -38,7 +38,6 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
-				"base contract",
 				"decimals:0x00",
 				"0x00",
 				"decimals()",
@@ -66,7 +65,6 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
-				"base contract",
 				"decimals:0x0000000000000000000000000000000000000000",
 				"0x0000000000000000000000000000000000000000",
 				"decimals()",
@@ -96,7 +94,6 @@ func TestProcessContractCalls(t *testing.T) {
 				},
 			},
 			want: multicall.ViewCalls{multicall.NewViewCall(
-				"sample erc20",
 				"balanceof:0x0000000000000000000000000000000000000000",
 				"0x0000000000000000000000000000000000000000",
 				"balanceOf(address)(uint256)",
@@ -133,14 +130,12 @@ func TestProcessContractCalls(t *testing.T) {
 			},
 			want: multicall.ViewCalls{
 				multicall.NewViewCall(
-					"sample erc20",
 					"balanceof:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"balanceOf(address)(uint256)",
 					[]interface{}{"0x71C7656EC7ab88b098defB751B7401B5f6d8976F"},
 				),
 				multicall.NewViewCall(
-					"sample erc20",
 					"allowance:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"allowance(address,address)(uint256)",
@@ -196,14 +191,12 @@ func TestProcessContractCalls(t *testing.T) {
 			},
 			want: multicall.ViewCalls{
 				multicall.NewViewCall(
-					"sample erc20",
 					"balanceof:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"balanceOf(address)(uint256)",
 					[]interface{}{"0x71C7656EC7ab88b098defB751B7401B5f6d8976F"},
 				),
 				multicall.NewViewCall(
-					"sample erc20",
 					"allowance:0x0000000000000000000000000000000000000000",
 					"0x0000000000000000000000000000000000000000",
 					"allowance(address,address)(uint256)",
@@ -213,7 +206,6 @@ func TestProcessContractCalls(t *testing.T) {
 					},
 				),
 				multicall.NewViewCall(
-					"sample pair",
 					"balanceof:0x0000000000000000000000000000000000000001",
 					"0x0000000000000000000000000000000000000001",
 					"balanceOf(address)(uint256)",

--- a/query/contracts/utils_test.go
+++ b/query/contracts/utils_test.go
@@ -24,7 +24,6 @@ func TestGetCallData(t *testing.T) {
 			name: "function with no argument",
 			args: args{
 				vcs: multicall.ViewCalls{multicall.NewViewCall(
-					"name",
 					"decimals:0x0000",
 					"0x0000",
 					"decimals()",
@@ -43,7 +42,6 @@ func TestGetCallData(t *testing.T) {
 			name: "function with one argument",
 			args: args{
 				vcs: multicall.ViewCalls{multicall.NewViewCall(
-					"name",
 					"balanceof:0x0000",
 					"0x0000",
 					"balanceOf(address)(uint256)",
@@ -64,7 +62,6 @@ func TestGetCallData(t *testing.T) {
 			name: "function with multiple arguments",
 			args: args{
 				vcs: multicall.ViewCalls{multicall.NewViewCall(
-					"name",
 					"dosomething:0x0000",
 					"0x0000",
 					"doSomething(address,address,uint256)(uint256)",


### PR DESCRIPTION
## Describe your changes
Added a function in main.go which will create routes for general contracts

## Tasks
- [x] updated ProcessContractCalls function to create keys for general contracts in query_contracts.go
- [x] added getGeneralContractRoutes function to create routes for general contracts in main.go
- [x] removed contract field  from viewcall.go and test files


## Issue ticket number and link
Ticket [ENG-766](https://linear.app/plexengineer/issue/ENG-766/feat-add-function-in-maingo-to-parse-contractsjson-so-routes-can-be)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added a good description to this PR
- [x] I have linked the ticket to this PR
